### PR TITLE
S3 endpoints

### DIFF
--- a/lib/wiki.stack.ts
+++ b/lib/wiki.stack.ts
@@ -56,30 +56,18 @@ export class WikiStack extends LPStack {
                                         'doc': {
                                             subresources: {
                                                 '{doc}': {
-                                                    subresources: {
-                                                        'delete': {
-                                                            endpoints: {
-                                                                GET: {
-                                                                    id: 'deleteDoc',
-                                                                    path: `${baseLambdaDir}/deletedoc`,
-                                                                },
-                                                            }
+                                                    endpoints: {
+                                                        DELETE: {
+                                                            id: 'deleteDoc',
+                                                            path: `${baseLambdaDir}/deletedoc`,
                                                         },
-                                                        'get': {
-                                                            endpoints: {
-                                                                GET: {
-                                                                    id: 'getDoc',
-                                                                    path: `${baseLambdaDir}/getdoc`,
-                                                                },
-                                                            },
+                                                        GET: {
+                                                            id: 'getDoc',
+                                                            path: `${baseLambdaDir}/getdoc`,
                                                         },
-                                                        'put': {
-                                                            endpoints: {
-                                                                GET: {
-                                                                    id: 'putDoc',
-                                                                    path: `${baseLambdaDir}/putdoc`,
-                                                                },
-                                                            }
+                                                        PUT: {
+                                                            id: 'putDoc',
+                                                            path: `${baseLambdaDir}/putdoc`,
                                                         }
                                                     }
                                                 },
@@ -91,36 +79,6 @@ export class WikiStack extends LPStack {
                         },
                     },
                 },
-                // deletedoc: {
-                //     endpoints: {
-                //         DELETE: {
-                //             id: 'deleteDoc',
-                //             path: `${baseLambdaDir}/deletedoc`,
-                //         },
-                //     },
-                //     subresources: {
-                //         'area': {
-                //             subresources: {
-                //                 '{area}': {
-                //                     subresources: {
-                //                         'doc': {
-                //                             subresources: {
-                //                                 '{doc}': {
-                //                                     endpoints: {
-                //                                         GET: {
-                //                                             id: 'getDoc',
-                //                                             path: `${baseLambdaDir}/getdoc`,
-                //                                         },
-                //                                     },
-                //                                 },
-                //                             },
-                //                         },
-                //                     },
-                //                 },
-                //             },
-                //         },
-                //     },
-                // },
             },
         };
 

--- a/lib/wiki.stack.ts
+++ b/lib/wiki.stack.ts
@@ -52,7 +52,7 @@ export class WikiStack extends LPStack {
                         'area': {
                             subresources: {
                                 '{area}': {
-                                    subresources: {
+                                    subresources: { 
                                         'doc': {
                                             subresources: {
                                                 '{doc}': {
@@ -72,6 +72,14 @@ export class WikiStack extends LPStack {
                                                                     path: `${baseLambdaDir}/getdoc`,
                                                                 },
                                                             },
+                                                        },
+                                                        'put': {
+                                                            endpoints: {
+                                                                GET: {
+                                                                    id: 'putDoc',
+                                                                    path: `${baseLambdaDir}/putdoc`,
+                                                                },
+                                                            }
                                                         }
                                                     }
                                                 },

--- a/lib/wiki.stack.ts
+++ b/lib/wiki.stack.ts
@@ -4,7 +4,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { config } from 'dotenv';
 import { LPStack, StackInfo } from './util/LPStack';
 import { ApiService, IApiResources } from './templates/apigateway';
-import * as s3 from 'aws-cdk-lib/aws-s3';
+// import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Role, ServicePrincipal, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 config();
 
@@ -27,16 +27,18 @@ export class WikiStack extends LPStack {
         policyStatement.addResources('arn:aws:s3:::lp-doc');
         role.addToPolicy(policyStatement);
 
-        const myBucket = new s3.Bucket(this, 'MyBucket', {
-            // S3 bucket configuration
-        });
+        // const myBucket = new s3.Bucket(this, 'MyBucket', {
+        //     // S3 bucket configuration
+        // });
 
         const lambdaConfigs = {
             runtime: lambda.Runtime.NODEJS_16_X,
             handler: 'index.handler',
             environment: {
-                BUCKET_NAME: myBucket.bucketName,
-                BUCKET_ARN: myBucket.bucketArn,
+                BUCKET_NAME: process.env.BUCKET_NAME || "",
+                BUCKET_ARN: process.env.BUCKET_NAME || "",
+                ACCESS_KEY: process.env.IAM_ACCESS_KEY || "",
+                SECRET_ACCESS_KEY: process.env.IAM_SECRET_ACCESS_KEY || ""
             },
             role: role,
         };
@@ -47,13 +49,33 @@ export class WikiStack extends LPStack {
             subresources: {
                 docs: {
                     subresources: {
-                        '{area}': {
+                        'area': {
                             subresources: {
-                                '{doc}': {
-                                    endpoints: {
-                                        GET: {
-                                            id: 'getDoc',
-                                            path: `${baseLambdaDir}/getdoc`,
+                                '{area}': {
+                                    subresources: {
+                                        'doc': {
+                                            subresources: {
+                                                '{doc}': {
+                                                    subresources: {
+                                                        'delete': {
+                                                            endpoints: {
+                                                                GET: {
+                                                                    id: 'deleteDoc',
+                                                                    path: `${baseLambdaDir}/deletedoc`,
+                                                                },
+                                                            }
+                                                        },
+                                                        'get': {
+                                                            endpoints: {
+                                                                GET: {
+                                                                    id: 'getDoc',
+                                                                    path: `${baseLambdaDir}/getdoc`,
+                                                                },
+                                                            },
+                                                        }
+                                                    }
+                                                },
+                                            },
                                         },
                                     },
                                 },
@@ -61,6 +83,36 @@ export class WikiStack extends LPStack {
                         },
                     },
                 },
+                // deletedoc: {
+                //     endpoints: {
+                //         DELETE: {
+                //             id: 'deleteDoc',
+                //             path: `${baseLambdaDir}/deletedoc`,
+                //         },
+                //     },
+                //     subresources: {
+                //         'area': {
+                //             subresources: {
+                //                 '{area}': {
+                //                     subresources: {
+                //                         'doc': {
+                //                             subresources: {
+                //                                 '{doc}': {
+                //                                     endpoints: {
+                //                                         GET: {
+                //                                             id: 'getDoc',
+                //                                             path: `${baseLambdaDir}/getdoc`,
+                //                                         },
+                //                                     },
+                //                                 },
+                //                             },
+                //                         },
+                //                     },
+                //                 },
+                //             },
+                //         },
+                //     },
+                // },
             },
         };
 
@@ -69,7 +121,6 @@ export class WikiStack extends LPStack {
             apiResources,
             `${WIKI_STACK_INFO.NAME}-API`,
             lambdaConfigs,
-            myBucket
         );
     }
 }

--- a/src/wiki/README.md
+++ b/src/wiki/README.md
@@ -1,0 +1,11 @@
+## Example GET:
+
+curl -X GET http://127.0.0.1:8000/docs/area/75504261:handbook/doc/objectives/
+
+## Example PUT:
+
+curl -X PUT -H "Content-Type: text/plain" --data-binary @docs/src/docs/handbook/objectives.md http://127.0.0.1:8000/docs/area/75504261:handbook/doc/objectives/
+
+## Example DELETE:
+
+curl -X DELETE http://127.0.0.1:8000/docs/area/75504261:handbook/doc/objectives/   

--- a/src/wiki/deletedoc.ts
+++ b/src/wiki/deletedoc.ts
@@ -6,8 +6,8 @@ export const handler = async function (
 ): Promise<APIGatewayProxyResult> {
     try {
         const s3 = new S3({
-            accessKeyId: process.env.IAM_ACCESS_KEY,
-            secretAccessKey: process.env.IAM_SECRET_ACCESS_KEY
+            accessKeyId: process.env.ACCESS_KEY,
+            secretAccessKey: process.env.SECRET_ACCESS_KEY
         });
         const bucketName = process.env.BUCKET_NAME;
 
@@ -29,8 +29,9 @@ export const handler = async function (
         }
 
         // Retrieve the bucket and key from the event
-        const objectKey = `${area}/${doc}.md`;
-
+        const trueArea = area.split(':').join('/');
+        const objectKey = `${trueArea}/${doc}.md`;
+        
         // Delete object
         const deleteObjectParams: S3.DeleteObjectRequest = {
             Bucket: bucketName,

--- a/src/wiki/deletedoc.ts
+++ b/src/wiki/deletedoc.ts
@@ -1,0 +1,63 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { S3 } from 'aws-sdk';
+
+export const handler = async function (
+    event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> {
+    try {
+        const s3 = new S3({
+            accessKeyId: process.env.IAM_ACCESS_KEY,
+            secretAccessKey: process.env.IAM_SECRET_ACCESS_KEY
+        });
+        const bucketName = process.env.BUCKET_NAME;
+
+        if (event === null) {
+            throw new Error('event not found');
+        }
+
+        if (!bucketName) {
+            throw new Error('Bucket not connected');
+        }
+
+        if (event.pathParameters === null) {
+            throw new Error('Request is missing params');
+        }
+
+        const { area, doc } = event.pathParameters;
+        if (!area || !doc) {
+            throw new Error('Request is missing params');
+        }
+
+        // Retrieve the bucket and key from the event
+        const objectKey = `${area}/${doc}.md`;
+
+        // Delete object
+        const deleteObjectParams: S3.DeleteObjectRequest = {
+            Bucket: bucketName,
+            Key: objectKey,
+        };
+
+        await s3.deleteObject(deleteObjectParams).promise();
+
+        return {
+            headers: {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+            },
+            statusCode: 200,
+            isBase64Encoded: false,
+            body: JSON.stringify({ message: 'File deleted successfully' })
+        };
+    } catch (error) {
+        console.log(error);
+        return {
+            headers: {
+                'Content-Type': 'application/json',
+                'Access-Control-Allow-Origin': '*',
+            },
+            statusCode: 500,
+            isBase64Encoded: false,
+            body: JSON.stringify({ error: 'Cannot delete resource' }),
+        };
+    }
+};

--- a/src/wiki/getdoc.ts
+++ b/src/wiki/getdoc.ts
@@ -1,11 +1,14 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { S3 } from 'aws-sdk';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 
 export const handler = async function (
     event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> {
     try {
-        const s3 = new S3();
+        const s3 = new S3({
+            accessKeyId: process.env.ACCESS_KEY,
+            secretAccessKey: process.env.SECRET_ACCESS_KEY
+        });
         const bucketName = process.env.BUCKET_NAME;
 
         if (event === null) {
@@ -25,17 +28,21 @@ export const handler = async function (
             throw new Error('Request is missing params');
         }
 
+        // ADD STRING.SPLIT METHOD THAT SPLITS LIKE AREA:AREA2:AREA3 AND TURNS INTO AREA/AREA2/AREA3 yup
         // Retrieve the bucket and key from the event
-        const objectKey = `${area}/${doc}.md`;
-
+        // const objectKey = `${area}/${doc}.md`;
+        const trueArea = area.split(':').join('/');
+        const objectKey = `${trueArea}/${doc}.md`;
+        console.log('objectKey:', objectKey)
         const getObjectParams: S3.GetObjectRequest = {
             Bucket: bucketName,
             Key: objectKey,
         };
-
+        console.log('objectParams:', getObjectParams)
         const s3Object = await s3.getObject(getObjectParams).promise();
         const objectData = s3Object.Body?.toString('utf-8');
-        console.log(objectData);
+        console.log('here?', getObjectParams)
+        console.log(s3Object)
         return {
             headers: {
                 'Content-Type': 'text/html',


### PR DESCRIPTION
Added delete and put endpoints, and altered endpoint convention (e.g. area/{area}/doc/{doc}). {area} allows for nested areas by using ":" (e.g. area/folder1:folder2:folder3/doc/test to access folder 3 contents). 

Since folders are not created explicitly in S3 (inferred from object keys), we don't really need separate endpoints for creating/deleting areas (unless there is some use case I didn't consider). 

Let me know if any changes or additions are required. 